### PR TITLE
Android Auto: media browser UI for music and audiobooks

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -20,7 +20,11 @@ jobs:
           java-version: "21"
       - name: Build Music release APK & AAB
         run: |
-          ./gradlew testReleaseUnitTest :apps:PlayerApp:assembleRelease :apps:PlayerApp:bundleRelease :apps:PlayerApp:publishReleaseBundle
+          ./gradlew \
+            :apps:PlayerApp:testReleaseUnitTest \
+            :apps:PlayerApp:assembleRelease \
+            :apps:PlayerApp:bundleRelease \
+            :apps:PlayerApp:publishReleaseBundle
         env:
           MUSIC_PLAYER_RELEASE_JKS_STORE_PASSWORD: ${{ secrets.MUSIC_PLAYER_RELEASE_JKS_STORE_PASSWORD }}
           MUSIC_PLAYER_RELEASE_JKS_KEY_PASSWORD: ${{ secrets.MUSIC_PLAYER_RELEASE_JKS_KEY_PASSWORD }}
@@ -47,7 +51,11 @@ jobs:
           java-version: "21"
       - name: Build Book release APK & AAB
         run: |
-          ./gradlew testReleaseUnitTest :apps:AudioBook:assembleRelease :apps:AudioBook:bundleRelease :apps:AudioBook:publishReleaseBundle
+          ./gradlew \
+            :apps:AudioBook:testReleaseUnitTest \
+            :apps:AudioBook:assembleRelease \
+            :apps:AudioBook:bundleRelease \
+            :apps:AudioBook:publishReleaseBundle
         env:
           AUDIO_BOOK_RELEASE_JKS_STORE_PASSWORD: ${{ secrets.AUDIO_BOOK_RELEASE_JKS_STORE_PASSWORD }}
           AUDIO_BOOK_RELEASE_JKS_KEY_PASSWORD: ${{ secrets.AUDIO_BOOK_RELEASE_JKS_KEY_PASSWORD }}

--- a/apps/AudioBook/src/main/java/by/tigre/audiobook/car/AudiobookCarMediaLibrary.kt
+++ b/apps/AudioBook/src/main/java/by/tigre/audiobook/car/AudiobookCarMediaLibrary.kt
@@ -1,0 +1,77 @@
+package by.tigre.audiobook.car
+
+import android.net.Uri
+import by.tigre.audiobook.core.data.audiobook.AudiobookCatalogSource
+import by.tigre.audiobook.core.data.audiobook_playback.AudiobookPlaybackController
+import by.tigre.audiobook.core.entity.catalog.Book
+import by.tigre.audiobook.core.entity.catalog.Chapter
+import by.tigre.music.player.core.presentation.backgound_player.car.CarBrowseItem
+import by.tigre.music.player.core.presentation.backgound_player.car.CarMediaIds
+import by.tigre.music.player.core.presentation.backgound_player.car.CarMediaLibrary
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+class AudiobookCarMediaLibrary(
+    private val scope: CoroutineScope,
+    private val catalog: AudiobookCatalogSource,
+    private val playback: AudiobookPlaybackController,
+    private val booksTabTitle: String,
+) : CarMediaLibrary {
+
+    override suspend fun getChildren(parentId: String): List<CarBrowseItem> = when (parentId) {
+        CarMediaIds.ROOT -> listOf(
+            CarBrowseItem(
+                id = CarMediaIds.TAB_BOOKS,
+                title = booksTabTitle,
+                isBrowsable = true,
+                isPlayable = false,
+            )
+        )
+        CarMediaIds.TAB_BOOKS -> catalog.getBooks().map { book -> bookItem(book, browsable = true) }
+        else -> {
+            val bookId = CarMediaIds.parseBookId(parentId) ?: return emptyList()
+            catalog.getChapters(Book.Id(bookId)).map { chapter -> chapterItem(bookId, chapter) }
+        }
+    }
+
+    override fun playMediaId(mediaId: String) {
+        CarMediaIds.parseChapterIds(mediaId)?.let { (bookId, chapterId) ->
+            playback.playBookChapter(Book.Id(bookId), Chapter.Id(chapterId))
+            return
+        }
+        CarMediaIds.parseBookId(mediaId)?.let { bookId ->
+            scope.launch {
+                catalog.getBook(Book.Id(bookId))?.let { playback.playBook(it) }
+            }
+        }
+    }
+
+    override suspend fun getBrowseItem(mediaId: String): CarBrowseItem? {
+        CarMediaIds.parseChapterIds(mediaId)?.let { (bookId, chapterId) ->
+            val chapter = catalog.getChapters(Book.Id(bookId))
+                .firstOrNull { it.id.value == chapterId } ?: return null
+            return chapterItem(bookId, chapter)
+        }
+        CarMediaIds.parseBookId(mediaId)?.let { bookId ->
+            val book = catalog.getBook(Book.Id(bookId)) ?: return null
+            return bookItem(book, browsable = true)
+        }
+        return null
+    }
+
+    private fun bookItem(book: Book, browsable: Boolean): CarBrowseItem = CarBrowseItem(
+        id = CarMediaIds.book(book.id.value),
+        title = book.title,
+        subtitle = book.chapterCount.takeIf { it > 0 }?.let { "$it chapters" },
+        isBrowsable = browsable,
+        isPlayable = !browsable,
+        artworkUri = book.coverUri?.let(Uri::parse),
+    )
+
+    private fun chapterItem(bookId: Long, chapter: Chapter): CarBrowseItem = CarBrowseItem(
+        id = CarMediaIds.chapter(bookId, chapter.id.value),
+        title = chapter.title,
+        isBrowsable = false,
+        isPlayable = true,
+    )
+}

--- a/apps/AudioBook/src/main/java/by/tigre/audiobook/core/di/ApplicationGraph.kt
+++ b/apps/AudioBook/src/main/java/by/tigre/audiobook/core/di/ApplicationGraph.kt
@@ -8,7 +8,10 @@ import by.tigre.audiobook.core.data.audiobook.di.AudiobookCatalogModule
 import by.tigre.audiobook.core.data.audiobook_playback.AudiobookPlaybackController
 import by.tigre.audiobook.core.data.audiobook_playback.di.AudiobookPlaybackModule
 import by.tigre.audiobook.core.data.storage.audiobook_catalog.di.AndroidAudiobookCatalogStorageModule
+import by.tigre.audiobook.car.AudiobookCarMediaLibrary
 import by.tigre.audiobook.core.presentation.audiobook_catalog.di.AudiobookCatalogDependency
+import by.tigre.background_player.R
+import by.tigre.music.player.core.presentation.backgound_player.car.CarMediaLibrary
 import by.tigre.audiobook.nighttimer.NightTimerController
 import by.tigre.audiobook.nighttimer.createNightTimerController
 import by.tigre.music.player.core.data.catalog.di.AndroidCatalogModule
@@ -28,6 +31,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOf
 
 class ApplicationGraph(
+    private val appContext: Context,
+    private val coroutineScope: kotlinx.coroutines.CoroutineScope,
     playbackModule: PlaybackModule,
     catalogModule: CatalogModule,
     audiobookCatalogModule: AudiobookCatalogModule,
@@ -46,6 +51,15 @@ class ApplicationGraph(
     override val appPlaybackVolume = playbackModule.appPlaybackVolume
 
     override val carSessionMediaType: Int = MediaMetadata.MEDIA_TYPE_AUDIO_BOOK
+
+    override val carMediaLibrary: CarMediaLibrary by lazy {
+        AudiobookCarMediaLibrary(
+            scope = coroutineScope,
+            catalog = audiobookCatalogSource,
+            playback = audiobookPlaybackController,
+            booksTabTitle = appContext.getString(R.string.car_tab_books),
+        )
+    }
 
     override val basePlaybackController: BasePlaybackController by lazy {
         val controller: AudiobookPlaybackController = audiobookPlaybackController
@@ -110,11 +124,13 @@ class ApplicationGraph(
             )
 
             return ApplicationGraph(
-                playbackModule,
-                catalogModule,
-                audiobookCatalogModule,
-                audiobookPlaybackModule,
-                nightTimerController,
+                appContext = context.applicationContext,
+                coroutineScope = coroutineModule.scope,
+                playbackModule = playbackModule,
+                catalogModule = catalogModule,
+                audiobookCatalogModule = audiobookCatalogModule,
+                audiobookPlaybackModule = audiobookPlaybackModule,
+                nightTimerController = nightTimerController,
             )
         }
     }

--- a/apps/PlayerApp/build.gradle.kts
+++ b/apps/PlayerApp/build.gradle.kts
@@ -111,6 +111,7 @@ dependencies {
     implementation(Project.Core.Music.Data.Playback)
     implementation(Project.Core.Music.Data.Catalog)
     implementation(Project.Core.Music.Entity.Catalog)
+    implementation(Project.Core.Music.Entity.Playback)
     implementation(Library.AccompanistPermission)
     implementation(FirebaseLibrary.FirebaseAnalytics, FirebaseLibrary.FirebaseCrashLytics)
 

--- a/apps/PlayerApp/src/main/java/by/tigre/music/player/car/MusicCarMediaLibrary.kt
+++ b/apps/PlayerApp/src/main/java/by/tigre/music/player/car/MusicCarMediaLibrary.kt
@@ -1,0 +1,127 @@
+package by.tigre.music.player.car
+
+import android.content.ContentUris
+import android.content.Context
+import android.provider.MediaStore
+import by.tigre.background_player.R
+import by.tigre.music.player.core.data.catalog.CatalogSource
+import by.tigre.music.player.core.data.playback.PlaybackController
+import by.tigre.music.player.core.entiry.catalog.Album
+import by.tigre.music.player.core.entiry.catalog.Artist
+import by.tigre.music.player.core.entiry.catalog.Song
+import by.tigre.music.player.core.presentation.backgound_player.car.CarBrowseItem
+import by.tigre.music.player.core.presentation.backgound_player.car.CarMediaIds
+import by.tigre.music.player.core.presentation.backgound_player.car.CarMediaLibrary
+import kotlinx.coroutines.flow.first
+
+class MusicCarMediaLibrary(
+    private val context: Context,
+    private val catalog: CatalogSource,
+    private val playback: PlaybackController,
+) : CarMediaLibrary {
+
+    override suspend fun getChildren(parentId: String): List<CarBrowseItem> = when (parentId) {
+        CarMediaIds.ROOT -> listOf(
+            browsableTab(CarMediaIds.TAB_ARTISTS, context.getString(R.string.car_tab_artists)),
+            browsableTab(CarMediaIds.TAB_QUEUE, context.getString(R.string.car_tab_queue)),
+        )
+        CarMediaIds.TAB_ARTISTS -> catalog.getArtists().map { artist ->
+            CarBrowseItem(
+                id = CarMediaIds.artist(artist.id.value),
+                title = artist.name,
+                subtitle = null,
+                isBrowsable = true,
+                isPlayable = false,
+            )
+        }
+        else -> when {
+            parentId.startsWith("artist/") -> {
+                val artistId = CarMediaIds.parseArtistId(parentId)?.let { Artist.Id(it) } ?: return emptyList()
+                catalog.getAlbums(artistId).map { album ->
+                    CarBrowseItem(
+                        id = CarMediaIds.album(artistId.value, album.id.value),
+                        title = album.name,
+                        subtitle = album.years.ifBlank { null },
+                        isBrowsable = true,
+                        isPlayable = false,
+                        artworkUri = albumArtUri(album.id.value),
+                    )
+                }
+            }
+            parentId.startsWith("album/") -> {
+                val (artistIdRaw, albumIdRaw) = CarMediaIds.parseAlbumIds(parentId) ?: return emptyList()
+                val artistId = Artist.Id(artistIdRaw)
+                val albumId = Album.Id(albumIdRaw)
+                catalog.getSongsByAlbum(artistId, albumId).map { song ->
+                    songItem(song)
+                }
+            }
+            parentId == CarMediaIds.TAB_QUEUE -> {
+                val queue = playback.currentQueue.first()
+                queue.map { item -> songItem(item.song) }
+            }
+            else -> emptyList()
+        }
+    }
+
+    override fun playMediaId(mediaId: String) {
+        CarMediaIds.parseSongId(mediaId)?.let {
+            playback.playSong(Song.Id(it))
+            return
+        }
+        CarMediaIds.parseAlbumIds(mediaId)?.let { (artistId, albumId) ->
+            playback.playAlbum(Album.Id(albumId), Artist.Id(artistId))
+            return
+        }
+        CarMediaIds.parseArtistId(mediaId)?.let {
+            playback.playArtist(Artist.Id(it))
+        }
+    }
+
+    override suspend fun getBrowseItem(mediaId: String): CarBrowseItem? {
+        CarMediaIds.parseSongId(mediaId)?.let { id ->
+            val song = catalog.getSongById(Song.Id(id)) ?: return null
+            return songItem(song)
+        }
+        CarMediaIds.parseAlbumIds(mediaId)?.let { (artistId, albumId) ->
+            val album = catalog.getAlbumById(Artist.Id(artistId), Album.Id(albumId)) ?: return null
+            return CarBrowseItem(
+                id = mediaId,
+                title = album.name,
+                subtitle = album.years.ifBlank { null },
+                isBrowsable = true,
+                isPlayable = false,
+                artworkUri = albumArtUri(album.id.value),
+            )
+        }
+        CarMediaIds.parseArtistId(mediaId)?.let { id ->
+            val artist = catalog.getArtistById(Artist.Id(id)) ?: return null
+            return CarBrowseItem(
+                id = mediaId,
+                title = artist.name,
+                isBrowsable = true,
+                isPlayable = false,
+            )
+        }
+        return null
+    }
+
+    private fun songItem(song: Song): CarBrowseItem = CarBrowseItem(
+        id = CarMediaIds.song(song.id.value),
+        title = song.name,
+        subtitle = "${song.artist} · ${song.album}",
+        isBrowsable = false,
+        isPlayable = true,
+        artworkUri = albumArtUri(song.albumId.value),
+    )
+
+    private fun browsableTab(id: String, title: String): CarBrowseItem = CarBrowseItem(
+        id = id,
+        title = title,
+        isBrowsable = true,
+        isPlayable = false,
+    )
+
+    private fun albumArtUri(albumId: Long) =
+        ContentUris.withAppendedId(MediaStore.Audio.Albums.EXTERNAL_CONTENT_URI, albumId)
+}

--- a/apps/PlayerApp/src/main/java/by/tigre/music/player/core/di/ApplicationGraph.kt
+++ b/apps/PlayerApp/src/main/java/by/tigre/music/player/core/di/ApplicationGraph.kt
@@ -9,6 +9,8 @@ import by.tigre.music.player.core.data.playback.di.AndroidBasePlaybackModule
 import by.tigre.music.player.core.data.playback.di.PlaybackModule
 import by.tigre.music.player.core.data.storage.playback_queue.di.AndroidPlaybackQueueModule
 import by.tigre.music.player.core.data.storage.preferences.di.AndroidPreferencesModule
+import by.tigre.music.player.car.MusicCarMediaLibrary
+import by.tigre.music.player.core.presentation.backgound_player.car.CarMediaLibrary
 import by.tigre.music.player.core.presentation.backgound_player.di.PlayerBackgroundDependency
 import by.tigre.music.player.core.presentation.catalog.component.BasePlaybackController
 import by.tigre.music.player.core.presentation.catalog.component.PlayerItem
@@ -19,8 +21,9 @@ import by.tigre.music.player.tools.coroutines.CoroutineModule
 import kotlinx.coroutines.flow.map
 
 class ApplicationGraph(
+    private val appContext: Context,
     playbackModule: PlaybackModule,
-    catalogModule: CatalogModule
+    catalogModule: CatalogModule,
 ) : CatalogDependency,
     PlayerDependency,
     PlayerBackgroundDependency,
@@ -29,6 +32,14 @@ class ApplicationGraph(
     CatalogModule by catalogModule {
 
     override val appPlaybackVolume = playbackModule.appPlaybackVolume
+
+    override val carMediaLibrary: CarMediaLibrary by lazy {
+        MusicCarMediaLibrary(
+            context = appContext,
+            catalog = catalogSource,
+            playback = playbackController,
+        )
+    }
 
     override val basePlaybackController: BasePlaybackController by lazy {
         val controller = playbackController
@@ -69,7 +80,7 @@ class ApplicationGraph(
             val playbackModule =
                 PlaybackModule.Impl(coroutineModule, playbackQueueModule, catalogModule, basePlaybackModule)
 
-            return ApplicationGraph(playbackModule, catalogModule)
+            return ApplicationGraph(context.applicationContext, playbackModule, catalogModule)
         }
     }
 }

--- a/core/base/presentation/background_player/src/main/kotlin/by/tigre/music/player/core/presentation/backgound_player/car/CarBrowseItem.kt
+++ b/core/base/presentation/background_player/src/main/kotlin/by/tigre/music/player/core/presentation/backgound_player/car/CarBrowseItem.kt
@@ -1,0 +1,12 @@
+package by.tigre.music.player.core.presentation.backgound_player.car
+
+import android.net.Uri
+
+data class CarBrowseItem(
+    val id: String,
+    val title: String,
+    val subtitle: String? = null,
+    val isBrowsable: Boolean,
+    val isPlayable: Boolean,
+    val artworkUri: Uri? = null,
+)

--- a/core/base/presentation/background_player/src/main/kotlin/by/tigre/music/player/core/presentation/backgound_player/car/CarMediaIds.kt
+++ b/core/base/presentation/background_player/src/main/kotlin/by/tigre/music/player/core/presentation/backgound_player/car/CarMediaIds.kt
@@ -1,0 +1,50 @@
+package by.tigre.music.player.core.presentation.backgound_player.car
+
+object CarMediaIds {
+    const val ROOT = "[ROOT]"
+
+    // Music
+    const val TAB_ARTISTS = "tab/artists"
+    const val TAB_QUEUE = "tab/queue"
+    private const val PREFIX_ARTIST = "artist/"
+    private const val PREFIX_ALBUM = "album/"
+    private const val PREFIX_SONG = "song/"
+
+    // Audiobook
+    const val TAB_BOOKS = "tab/books"
+    private const val PREFIX_BOOK = "book/"
+    private const val PREFIX_CHAPTER = "chapter/"
+
+    fun artist(id: Long): String = "$PREFIX_ARTIST$id"
+    fun album(artistId: Long, albumId: Long): String = "$PREFIX_ALBUM$artistId/$albumId"
+    fun song(songId: Long): String = "$PREFIX_SONG$songId"
+    fun book(bookId: Long): String = "$PREFIX_BOOK$bookId"
+    fun chapter(bookId: Long, chapterId: Long): String = "$PREFIX_CHAPTER$bookId/$chapterId"
+
+    fun parseArtistId(mediaId: String): Long? =
+        mediaId.removePrefix(PREFIX_ARTIST).toLongOrNull()
+
+    fun parseAlbumIds(mediaId: String): Pair<Long, Long>? {
+        if (!mediaId.startsWith(PREFIX_ALBUM)) return null
+        val parts = mediaId.removePrefix(PREFIX_ALBUM).split('/')
+        if (parts.size != 2) return null
+        val artistId = parts[0].toLongOrNull() ?: return null
+        val albumId = parts[1].toLongOrNull() ?: return null
+        return artistId to albumId
+    }
+
+    fun parseSongId(mediaId: String): Long? =
+        mediaId.removePrefix(PREFIX_SONG).toLongOrNull()
+
+    fun parseBookId(mediaId: String): Long? =
+        mediaId.removePrefix(PREFIX_BOOK).toLongOrNull()
+
+    fun parseChapterIds(mediaId: String): Pair<Long, Long>? {
+        if (!mediaId.startsWith(PREFIX_CHAPTER)) return null
+        val parts = mediaId.removePrefix(PREFIX_CHAPTER).split('/')
+        if (parts.size != 2) return null
+        val bookId = parts[0].toLongOrNull() ?: return null
+        val chapterId = parts[1].toLongOrNull() ?: return null
+        return bookId to chapterId
+    }
+}

--- a/core/base/presentation/background_player/src/main/kotlin/by/tigre/music/player/core/presentation/backgound_player/car/CarMediaItemFactory.kt
+++ b/core/base/presentation/background_player/src/main/kotlin/by/tigre/music/player/core/presentation/backgound_player/car/CarMediaItemFactory.kt
@@ -1,0 +1,33 @@
+package by.tigre.music.player.core.presentation.backgound_player.car
+
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+
+internal object CarMediaItemFactory {
+
+    fun rootItem(): MediaItem =
+        MediaItem.Builder()
+            .setMediaId(CarMediaIds.ROOT)
+            .setMediaMetadata(
+                MediaMetadata.Builder()
+                    .setIsBrowsable(true)
+                    .setIsPlayable(false)
+                    .setTitle("")
+                    .build()
+            )
+            .build()
+
+    fun fromBrowseItem(item: CarBrowseItem, mediaType: Int): MediaItem {
+        val metadata = MediaMetadata.Builder()
+            .setTitle(item.title)
+            .setMediaType(mediaType)
+            .setIsBrowsable(item.isBrowsable)
+            .setIsPlayable(item.isPlayable)
+        item.subtitle?.let { metadata.setArtist(it) }
+        item.artworkUri?.let { metadata.setArtworkUri(it) }
+        return MediaItem.Builder()
+            .setMediaId(item.id)
+            .setMediaMetadata(metadata.build())
+            .build()
+    }
+}

--- a/core/base/presentation/background_player/src/main/kotlin/by/tigre/music/player/core/presentation/backgound_player/car/CarMediaLibrary.kt
+++ b/core/base/presentation/background_player/src/main/kotlin/by/tigre/music/player/core/presentation/backgound_player/car/CarMediaLibrary.kt
@@ -1,0 +1,20 @@
+package by.tigre.music.player.core.presentation.backgound_player.car
+
+/**
+ * Catalog tree for Android Auto / Android for Cars media browser.
+ * Implemented per app (music vs audiobook).
+ */
+interface CarMediaLibrary {
+
+    /** Children of [parentId]; use [CarMediaIds.ROOT] for top-level tabs. */
+    suspend fun getChildren(parentId: String): List<CarBrowseItem>
+
+    /** Start playback for a single browsable/playable item. */
+    fun playMediaId(mediaId: String)
+
+    /** Replace queue / play a list (e.g. album or queue tab). */
+    fun playMediaIds(mediaIds: List<String>) {}
+
+    /** Resolve a single item for [onGetItem]; return null if unknown. */
+    suspend fun getBrowseItem(mediaId: String): CarBrowseItem? = null
+}

--- a/core/base/presentation/background_player/src/main/kotlin/by/tigre/music/player/core/presentation/backgound_player/car/CarMediaLibrarySessionCallback.kt
+++ b/core/base/presentation/background_player/src/main/kotlin/by/tigre/music/player/core/presentation/backgound_player/car/CarMediaLibrarySessionCallback.kt
@@ -16,7 +16,9 @@ import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @OptIn(UnstableApi::class)
 internal class CarMediaLibrarySessionCallback(
@@ -77,7 +79,9 @@ internal class CarMediaLibrarySessionCallback(
         val future = SettableFuture.create<LibraryResult<MediaItem>>()
         scope.launch {
             try {
-                val item = carMediaLibrary.getBrowseItem(mediaId)
+                val item = withContext(Dispatchers.IO) {
+                    carMediaLibrary.getBrowseItem(mediaId)
+                }
                 if (item != null) {
                     future.set(
                         LibraryResult.ofItem(
@@ -130,7 +134,9 @@ internal class CarMediaLibrarySessionCallback(
         val future = SettableFuture.create<LibraryResult<ImmutableList<MediaItem>>>()
         scope.launch {
             try {
-                val browseItems = carMediaLibrary.getChildren(parentId)
+                val browseItems = withContext(Dispatchers.IO) {
+                    carMediaLibrary.getChildren(parentId)
+                }
                 val mediaItems = browseItems.map { CarMediaItemFactory.fromBrowseItem(it, carSessionMediaType) }
                 future.set(LibraryResult.ofItemList(ImmutableList.copyOf(mediaItems), null))
             } catch (e: Exception) {

--- a/core/base/presentation/background_player/src/main/kotlin/by/tigre/music/player/core/presentation/backgound_player/car/CarMediaLibrarySessionCallback.kt
+++ b/core/base/presentation/background_player/src/main/kotlin/by/tigre/music/player/core/presentation/backgound_player/car/CarMediaLibrarySessionCallback.kt
@@ -1,0 +1,143 @@
+package by.tigre.music.player.core.presentation.backgound_player.car
+
+import android.os.Bundle
+import androidx.annotation.OptIn
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.LibraryResult
+import androidx.media3.session.MediaConstants
+import androidx.media3.session.MediaLibraryService
+import androidx.media3.session.MediaLibraryService.MediaLibrarySession
+import androidx.media3.session.MediaSession
+import androidx.media3.session.MediaSession.MediaItemsWithStartPosition
+import androidx.media3.session.SessionError
+import com.google.common.collect.ImmutableList
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.SettableFuture
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@OptIn(UnstableApi::class)
+internal class CarMediaLibrarySessionCallback(
+    private val scope: CoroutineScope,
+    private val carMediaLibrary: CarMediaLibrary,
+    private val carSessionMediaType: Int,
+) : MediaLibrarySession.Callback {
+
+    override fun onConnect(
+        session: MediaSession,
+        controller: MediaSession.ControllerInfo,
+    ): MediaSession.ConnectionResult {
+        return MediaSession.ConnectionResult.accept(
+            MediaSession.ConnectionResult.DEFAULT_SESSION_AND_LIBRARY_COMMANDS,
+            MediaSession.ConnectionResult.DEFAULT_PLAYER_COMMANDS,
+        )
+    }
+
+    override fun onGetLibraryRoot(
+        session: MediaLibrarySession,
+        browser: MediaSession.ControllerInfo,
+        params: MediaLibraryService.LibraryParams?,
+    ): ListenableFuture<LibraryResult<MediaItem>> {
+        val rootExtras = Bundle().apply {
+            putInt(
+                MediaConstants.EXTRAS_KEY_CONTENT_STYLE_BROWSABLE,
+                MediaConstants.EXTRAS_VALUE_CONTENT_STYLE_LIST_ITEM,
+            )
+            putInt(
+                MediaConstants.EXTRAS_KEY_CONTENT_STYLE_PLAYABLE,
+                MediaConstants.EXTRAS_VALUE_CONTENT_STYLE_LIST_ITEM,
+            )
+        }
+        val libraryParams = MediaLibraryService.LibraryParams.Builder()
+            .setExtras(rootExtras)
+            .build()
+        return Futures.immediateFuture(
+            LibraryResult.ofItem(CarMediaItemFactory.rootItem(), libraryParams)
+        )
+    }
+
+    override fun onGetChildren(
+        session: MediaLibrarySession,
+        browser: MediaSession.ControllerInfo,
+        parentId: String,
+        page: Int,
+        pageSize: Int,
+        params: MediaLibraryService.LibraryParams?,
+    ): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> {
+        return loadChildren(parentId)
+    }
+
+    override fun onGetItem(
+        session: MediaLibrarySession,
+        browser: MediaSession.ControllerInfo,
+        mediaId: String,
+    ): ListenableFuture<LibraryResult<MediaItem>> {
+        val future = SettableFuture.create<LibraryResult<MediaItem>>()
+        scope.launch {
+            try {
+                val item = carMediaLibrary.getBrowseItem(mediaId)
+                if (item != null) {
+                    future.set(
+                        LibraryResult.ofItem(
+                            CarMediaItemFactory.fromBrowseItem(item, carSessionMediaType),
+                            null,
+                        )
+                    )
+                } else {
+                    future.set(LibraryResult.ofError(SessionError.ERROR_BAD_VALUE))
+                }
+            } catch (e: Exception) {
+                future.set(LibraryResult.ofError(SessionError.ERROR_UNKNOWN))
+            }
+        }
+        return future
+    }
+
+    override fun onAddMediaItems(
+        mediaSession: MediaSession,
+        controller: MediaSession.ControllerInfo,
+        mediaItems: MutableList<MediaItem>,
+    ): ListenableFuture<MutableList<MediaItem>> {
+        playFromMediaItems(mediaItems)
+        return Futures.immediateFuture(mediaItems)
+    }
+
+    override fun onSetMediaItems(
+        mediaSession: MediaSession,
+        controller: MediaSession.ControllerInfo,
+        mediaItems: MutableList<MediaItem>,
+        startIndex: Int,
+        startPositionMs: Long,
+    ): ListenableFuture<MediaItemsWithStartPosition> {
+        playFromMediaItems(mediaItems)
+        return Futures.immediateFuture(
+            MediaItemsWithStartPosition(mediaItems, startIndex, startPositionMs)
+        )
+    }
+
+    private fun playFromMediaItems(mediaItems: List<MediaItem>) {
+        val ids = mediaItems.map { it.mediaId }
+        if (ids.size == 1) {
+            carMediaLibrary.playMediaId(ids.first())
+        } else if (ids.isNotEmpty()) {
+            carMediaLibrary.playMediaIds(ids)
+        }
+    }
+
+    private fun loadChildren(parentId: String): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> {
+        val future = SettableFuture.create<LibraryResult<ImmutableList<MediaItem>>>()
+        scope.launch {
+            try {
+                val browseItems = carMediaLibrary.getChildren(parentId)
+                val mediaItems = browseItems.map { CarMediaItemFactory.fromBrowseItem(it, carSessionMediaType) }
+                future.set(LibraryResult.ofItemList(ImmutableList.copyOf(mediaItems), null))
+            } catch (e: Exception) {
+                future.set(LibraryResult.ofError(SessionError.ERROR_UNKNOWN))
+            }
+        }
+        return future
+    }
+
+}

--- a/core/base/presentation/background_player/src/main/kotlin/by/tigre/music/player/core/presentation/backgound_player/di/PlayerBackgroundDependency.kt
+++ b/core/base/presentation/background_player/src/main/kotlin/by/tigre/music/player/core/presentation/backgound_player/di/PlayerBackgroundDependency.kt
@@ -1,10 +1,12 @@
 package by.tigre.music.player.core.presentation.backgound_player.di
 
 import androidx.media3.common.MediaMetadata
+import by.tigre.music.player.core.presentation.backgound_player.car.CarMediaLibrary
 import by.tigre.music.player.core.presentation.catalog.component.BasePlaybackController
 
 interface PlayerBackgroundDependency {
     val basePlaybackController: BasePlaybackController
+    val carMediaLibrary: CarMediaLibrary
 
     /** [MediaMetadata.MediaType] for Android Auto / Automotive session display. */
     val carSessionMediaType: Int get() = MediaMetadata.MEDIA_TYPE_MUSIC

--- a/core/base/presentation/background_player/src/main/kotlin/by/tigre/music/player/core/presentation/backgound_player/presentation/component/BackgroundComponent.kt
+++ b/core/base/presentation/background_player/src/main/kotlin/by/tigre/music/player/core/presentation/backgound_player/presentation/component/BackgroundComponent.kt
@@ -1,6 +1,7 @@
 package by.tigre.music.player.core.presentation.backgound_player.presentation.component
 
 import by.tigre.music.player.core.data.playback.PlaybackPlayer
+import by.tigre.music.player.core.presentation.backgound_player.car.CarMediaLibrary
 import by.tigre.music.player.core.presentation.backgound_player.di.PlayerBackgroundDependency
 import by.tigre.music.player.core.presentation.catalog.component.PlayerItem
 import kotlinx.coroutines.CoroutineScope
@@ -13,6 +14,7 @@ interface BackgroundComponent : CoroutineScope {
 
     val currentItem: Flow<PlayerItem?>
     val carSessionMediaType: Int
+    val carMediaLibrary: CarMediaLibrary
 
     fun getPlayer(): PlaybackPlayer
 
@@ -30,6 +32,7 @@ interface BackgroundComponent : CoroutineScope {
         private val playbackController = dependency.basePlaybackController
 
         override val carSessionMediaType: Int = dependency.carSessionMediaType
+        override val carMediaLibrary: CarMediaLibrary = dependency.carMediaLibrary
 
         override val currentItem: Flow<PlayerItem?> = playbackController.currentItem
 

--- a/core/base/presentation/background_player/src/main/kotlin/by/tigre/music/player/core/presentation/backgound_player/presentation/platform/PlaybackService.kt
+++ b/core/base/presentation/background_player/src/main/kotlin/by/tigre/music/player/core/presentation/backgound_player/presentation/platform/PlaybackService.kt
@@ -3,8 +3,8 @@ package by.tigre.music.player.core.presentation.backgound_player.presentation.pl
 import android.content.Intent
 import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
-import androidx.media3.session.MediaSessionService
 import by.tigre.music.player.core.presentation.backgound_player.di.PlayerBackgroundDependency
 import by.tigre.music.player.core.presentation.backgound_player.presentation.component.BackgroundComponent
 import by.tigre.music.player.core.presentation.backgound_player.presentation.view.BackgroundPlayerView
@@ -12,7 +12,7 @@ import by.tigre.logger.Log
 import kotlinx.coroutines.cancel
 
 @OptIn(UnstableApi::class)
-abstract class PlaybackService : MediaSessionService() {
+abstract class PlaybackService : MediaLibraryService() {
 
     private val component: BackgroundComponent by lazy {
         BackgroundComponent.Impl(dependency = onProviderDependency())
@@ -37,7 +37,8 @@ abstract class PlaybackService : MediaSessionService() {
         super.onUpdateNotification(session, session.player.playWhenReady) // hack for "stop playing in background"
     }
 
-    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? = view.onGetSession()
+    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibraryService.MediaLibrarySession? =
+        view.onGetSession()
 
     override fun onDestroy() {
         super.onDestroy()

--- a/core/base/presentation/background_player/src/main/kotlin/by/tigre/music/player/core/presentation/backgound_player/presentation/view/BackgroundPlayerView.kt
+++ b/core/base/presentation/background_player/src/main/kotlin/by/tigre/music/player/core/presentation/backgound_player/presentation/view/BackgroundPlayerView.kt
@@ -3,7 +3,6 @@ package by.tigre.music.player.core.presentation.backgound_player.presentation.vi
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
-import android.app.Service
 import android.content.Intent
 import android.net.Uri
 import androidx.annotation.OptIn
@@ -12,8 +11,10 @@ import androidx.media3.common.Player
 import by.tigre.music.player.core.data.playback.AndroidPlaybackPlayer
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.DefaultMediaNotificationProvider
+import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaNotification
 import androidx.media3.session.MediaSession
+import by.tigre.music.player.core.presentation.backgound_player.car.CarMediaLibrarySessionCallback
 import by.tigre.background_player.R
 import by.tigre.music.player.core.presentation.backgound_player.presentation.component.BackgroundComponent
 import by.tigre.music.player.core.presentation.catalog.component.PlayerItem
@@ -27,14 +28,14 @@ import kotlinx.coroutines.launch
 
 @OptIn(UnstableApi::class)
 class BackgroundPlayerView(
-    private val service: Service,
+    private val service: MediaLibraryService,
     private val component: BackgroundComponent,
     private val onIntentProvider: () -> Intent
 ) {
     private val scope = CoroutineScope(Dispatchers.Main)
     private val notificationManager = service.getNotificationManager()
 
-    private var mediaSession: MediaSession? = null
+    private var mediaSession: MediaLibraryService.MediaLibrarySession? = null
 
     init {
         val nc = NotificationChannel(
@@ -60,7 +61,12 @@ class BackgroundPlayerView(
             (component.getPlayer() as AndroidPlaybackPlayer).player,
             currentPlayerItem
         )
-        mediaSession = MediaSession.Builder(service, player)
+        val callback = CarMediaLibrarySessionCallback(
+            scope = scope,
+            carMediaLibrary = component.carMediaLibrary,
+            carSessionMediaType = component.carSessionMediaType,
+        )
+        mediaSession = MediaLibraryService.MediaLibrarySession.Builder(service, player, callback)
             .setSessionActivity(
                 PendingIntent.getActivity(
                     service,
@@ -78,7 +84,7 @@ class BackgroundPlayerView(
         mediaSession = null
     }
 
-    fun onGetSession(): MediaSession? = mediaSession
+    fun onGetSession(): MediaLibraryService.MediaLibrarySession? = mediaSession
     fun mediaNotificationProvider(): MediaNotification.Provider {
         return mediaNotificationProvider
     }

--- a/core/base/presentation/background_player/src/main/res/values-ru/string.xml
+++ b/core/base/presentation/background_player/src/main/res/values-ru/string.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="notification_channel_name">Воспроизведение</string>
+    <string name="car_tab_artists">Исполнители</string>
+    <string name="car_tab_queue">Очередь</string>
+    <string name="car_tab_books">Книги</string>
 </resources>

--- a/core/base/presentation/background_player/src/main/res/values/string.xml
+++ b/core/base/presentation/background_player/src/main/res/values/string.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="notification_channel_name">Playback</string>
+    <string name="car_tab_artists">Artists</string>
+    <string name="car_tab_queue">Queue</string>
+    <string name="car_tab_books">Books</string>
 </resources>

--- a/core/book/data/playback/src/commonMain/kotlin/by/tigre/audiobook/core/data/audiobook_playback/AudiobookPlaybackController.kt
+++ b/core/book/data/playback/src/commonMain/kotlin/by/tigre/audiobook/core/data/audiobook_playback/AudiobookPlaybackController.kt
@@ -15,6 +15,7 @@ interface AudiobookPlaybackController {
 
     fun loadBook(book: Book)
     fun playBook(book: Book)
+    fun playBookChapter(bookId: Book.Id, chapterId: Chapter.Id)
     fun playNextChapter()
     fun playPrevChapter()
     fun pause()

--- a/core/book/data/playback/src/commonMain/kotlin/by/tigre/audiobook/core/data/audiobook_playback/impl/AudiobookPlaybackControllerImpl.kt
+++ b/core/book/data/playback/src/commonMain/kotlin/by/tigre/audiobook/core/data/audiobook_playback/impl/AudiobookPlaybackControllerImpl.kt
@@ -92,6 +92,26 @@ internal class AudiobookPlaybackControllerImpl(
         }
     }
 
+    override fun playBookChapter(bookId: Book.Id, chapterId: Chapter.Id) {
+        Log.d(TAG) { "playBookChapter: bookId=$bookId chapterId=$chapterId" }
+        scope.launch {
+            val book = catalog.getBook(bookId) ?: return@launch
+            val chapterList = catalog.getChapters(bookId)
+            val chapter = chapterList.firstOrNull { it.id == chapterId } ?: return@launch
+            dismissBookFinishedBanner()
+            chapters.value = chapterList
+            currentBook.value = book
+            loadCanonicalListenedMs = null
+            mayPersistBelowCanonical = false
+            storage.saveLastPlayedBook(book.id)
+            setChapter(chapter, 0L)
+            isPlaying.value = true
+            applyRewindBeforePlaybackResume()
+            player.resume()
+            saveCurrentPosition()
+        }
+    }
+
     private suspend fun loadBookInternal(book: Book, autoPlay: Boolean) {
         val chapterList = catalog.getChapters(book.id)
         if (chapterList.isEmpty()) {


### PR DESCRIPTION
## Summary
- Migrate background playback to Media3 `MediaLibraryService` so Android Auto shows the standard browse + now-playing UI.
- Music Player: root tabs **Artists** (artist → album → song) and **Queue**.
- AudioBook: **Books** → chapters; add `playBookChapter` for chapter playback from Auto.

## Test plan
- [ ] Connect phone to Android Auto, open Music Player — verify Artists/Queue tabs and playback from car screen.
- [ ] Repeat for AudioBook — Books list, chapters, now-playing metadata.
- [ ] Confirm steering-wheel / head-unit controls still work.
- [ ] Verify phone notification playback unchanged.

Made with [Cursor](https://cursor.com)