### PR TITLE
Audiobook chapter UX and AI-optimized project docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS.md
+
+AI agents: read **[CLAUDE.md](CLAUDE.md)** for full project context.
+
+Quick facts:
+- Kotlin monorepo — 3 apps (`PlayerApp`, `AudioBook`, `PlayerDesktop`) + shared KMP `core:*` modules
+- Pattern: manual DI (`ApplicationGraph`) + Decompose + Component/View split
+- Shared code → `core:*`; app wiring → `apps:*`
+- Stable typos: package `entiry`, dir `backgound_player` — do not rename
+- Verify: `./gradlew :apps:PlayerApp:assembleDebug` or `./gradlew :apps:PlayerDesktop:run`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,159 +1,271 @@
-# CLAUDE.md
+# CLAUDE.md — AI context for this repository
 
-This file provides guidance to Claude Code (claude.ai/code) when working in this repository.
+Kotlin monorepo: **3 apps** (2 Android + 1 Desktop) sharing KMP modules. Architecture: **manual DI** (`ApplicationGraph`) + **Decompose** navigation + **Component/View** split. Read this file before making changes.
 
-## Build Commands
-```bash
-# Debug build – generates a debuggable APK for local testing
-echo "Running debug build"
-./gradlew assembleDebug
+---
 
-# QA build (Firebase App Distribution) – includes minification and Firebase upload
-echo "Building QA variant"
-./gradlew assembleQa
+## Quick routing — where to work
 
-# Release build – requires release keystore credentials set as environment variables
-echo "Preparing release build"
-./gradlew assembleRelease 
+| Task | Start here |
+|------|------------|
+| Android music player shell / root nav | `apps/PlayerApp/src/main/java/by/tigre/music/player/` |
+| Android audiobook shell / night timer | `apps/AudioBook/src/main/java/by/tigre/audiobook/` |
+| Desktop app shell / windows | `apps/PlayerDesktop/src/main/kotlin/by/tigre/music/player/desktop/` |
+| Shared music catalog UI | `core/music/presentation/catalog/` |
+| Shared player / equalizer UI | `core/base/presentation/player/` |
+| Shared queue UI | `core/music/presentation/playlist/queue/` |
+| Audiobook catalog UI | `core/book/presentation/catalog/` |
+| Playback engine (ExoPlayer / JVM) | `core/base/data/playback/` |
+| Music playback + queue logic | `core/music/data/playback/` |
+| Audiobook chapter playback | `core/book/data/playback/` |
+| SQLDelight schemas | `core/*/data/storage/database/src/commonMain/sqldelight/` |
+| Compose theme / shared widgets | `tools/presentation/compose/` |
+| Decompose helpers | `tools/presentation/decompose/` |
+| Dependency versions | `buildSrc/src/main/kotlin/Dependencies.kt` |
+| App IDs / SDK / versions | `buildSrc/src/main/kotlin/Application.kt` |
+| Module registry | `settings.gradle.kts` |
 
-# Run all unit tests across modules
-./gradlew test
+**Rule of thumb:** UI and domain logic go in `core:*` KMP modules; app-specific wiring (DI graph, root nav, Car, night timer) stays in `apps:*`.
 
-# Check for dependency updates (Gradle Versions Plugin)
-echo "Checking dependencies"
-./gradlew dependencyUpdates
+---
 
-# Generate SQLDelight database code from .sq files
-echo "Generating SQLDelight interfaces"
-./gradlew generateSqlDelightInterface
+## Apps
+
+### PlayerApp (Android music player)
+- Package: `by.tigre.music.player` | App ID: `by.tigre.musicplayer` (no dot)
+- Entry: `apps/PlayerApp/.../App.kt`, `MainActivity.kt`
+- DI: `apps/PlayerApp/.../core/di/ApplicationGraph.kt`
+- Root nav: `apps/PlayerApp/.../presentation/root/component/Root.kt`
+- Car: `apps/PlayerApp/.../car/MusicCarMediaLibrary.kt`
+- Playback: `playbackController` (songs from MediaStore)
+
+### AudioBook (Android audiobook, WIP)
+- Package: `by.tigre.audiobook` | App ID: `by.tigre.audiobook`
+- Entry: `apps/AudioBook/.../App.kt`, `MainActivity.kt`
+- DI: `apps/AudioBook/.../core/di/ApplicationGraph.kt` — extends PlayerApp graph + book modules + `nightTimerController`
+- Root nav: `apps/AudioBook/.../presentation/root/component/Root.kt` — initial screen is **Player**, not catalog
+- Playback: `audiobookPlaybackController` (books/chapters); prev/next = ±60s seek, not track skip
+- App-only features: night timer (`apps/AudioBook/.../nighttimer/`), face-down extender, audiobook Car library
+- Still uses shared music modules for queue infra, preferences, base playback
+
+### PlayerDesktop (JVM Compose Desktop)
+- Package: `by.tigre.music.player.desktop`
+- Entry: `apps/PlayerDesktop/.../desktop/Main.kt`
+- DI: `apps/PlayerDesktop/.../desktop/di/ApplicationGraph.kt` (`DesktopApplicationGraph`)
+- Multi-window UI (library, player, equalizer) — not single-activity Android nav
+- Data dir: `~/.music-player`
+- No Firebase, Car, permissions, `background_player`, or `debug:settings`
+- Logger: console only
+
+---
+
+## Module map
+
+```
+apps:PlayerApp          — Android music app
+apps:AudioBook          — Android audiobook app
+apps:PlayerDesktop      — Desktop music app
+
+core:base:data:playback              — ExoPlayer/JVM playback, equalizer, app volume
+core:base:presentation:player        — Player, mini-player, equalizer UI
+core:base:presentation:background_player — Android MediaSessionService + Car (Android-only)
+
+core:music:entity:catalog|playback   — Song, Artist, Album, SongInQueueItem
+core:music:data:catalog              — MediaStore (Android) / folder scan (Desktop)
+core:music:data:playback             — Music PlaybackController
+core:music:data:storage:database     — SQLDelight queue (DatabaseMusic)
+core:music:presentation:catalog      — Artists → Albums → Songs UI
+core:music:presentation:playlist:queue — Queue management UI
+
+core:book:entity:catalog             — Book, chapter entities
+core:book:data:catalog|playback|storage:database — Audiobook data layer
+core:book:presentation:catalog       — Audiobook library UI
+
+core:data:storage:preferences        — SharedPreferences / desktop prefs
+core:platform:permission             — Runtime permissions (Android)
+
+tools:presentation:compose|decompose — Shared UI theme + Decompose base
+tools:entity|coroutines|platform:utils
+debug:settings                       — Debug log viewer (Android debug/qa only)
 ```
 
-## Build Variants
-| Variant     | Debuggable | Minify | App ID Suffix |
-|-------------|------------|--------|---------------|
-| **debug**   | ✓          | ✗      | `.dev`        |
-| **qa**      | ✓          | ✓      | `.dev`        |
-| **release** | ✗          | ✓      | _(none)_      |
+### Dependency layering (do not violate)
 
-## Environment Variables (Release Signing)
+```
+apps → presentation → data → entity
+                    ↘ base:data:playback, tools:*
+```
 
-- **Music Player:**
-  - `MUSIC_PLAYER_RELEASE_JKS_STORE_PASSWORD`
-  - `MUSIC_PLAYER_RELEASE_JKS_KEY_PASSWORD`
+- `entity` modules: pure Kotlin types, no Android/Compose
+- `data` modules: repositories, playback, SQLDelight
+- `presentation` modules: Component + View + Providers (KMP: commonMain + androidMain + desktopMain)
+- `apps` modules: wire graphs, root navigation, platform-only code
 
-- **AudioBook:**
-  - `AUDIO_BOOK_RELEASE_JKS_STORE_PASSWORD`
-  - `AUDIO_BOOK_RELEASE_JKS_KEY_PASSWORD`
+---
 
-## Project Architecture
+## Architecture patterns
 
-Two Android apps built with Kotlin and Jetpack Compose, sharing a common set of modules. Uses a modular multi-project architecture with
-manual dependency injection and Decompose for navigation.
+### Manual DI
+1. `ApplicationGraph.create()` in `App.onCreate()` — root container
+2. `*Dependency` interface — what a feature needs from the graph
+3. `*Module` with `Impl` — data-layer factories
+4. `*ComponentProvider.Impl(dependency)` — creates Decompose components
 
-- Compile SDK: 34 | Target SDK: 33 | Min SDK: 26 | Java: 17
+### Decompose navigation
+- `StackNavigation` + `@Serializable` sealed config classes
+- Components extend `BaseComponentContext` (= `ComponentContext` + `CoroutineScope`)
+  - `tools/presentation/decompose/.../BaseComponentContext.kt`
+- Child stacks: `appChildStack`, `appChildContext` extensions in same module
+- Nested example: `RootCatalogComponent` (Artists → Albums → Songs)
 
-### App Modules
+### Component / View split (every feature)
 
-- **apps:PlayerApp** – Music Player app
-- **apps:AudioBook** – Audiobook app (WIP)
+| File | Role |
+|------|------|
+| `*Component.kt` | Logic: interface + `Impl` |
+| `*View.kt` | UI: class implementing `ComposableView` with `.Draw(Modifier)` |
+| `*ComponentProvider.kt` | Factory: `interface + Impl(dependency)` |
+| `*ViewProvider.kt` | Factory for views |
+| `navigation/*Navigator.kt` | Navigation callbacks; implemented in parent component or app `Root` |
 
-### Shared Module Structure
+Reference implementation — music catalog artist list:
+- Component: `core/music/presentation/catalog/.../component/ArtistListComponent.kt`
+- View: `.../view/ArtistListView.kt`
+- Providers: `.../di/CatalogComponentProvider.kt`, `CatalogViewProvider.kt`
+- Navigator: `.../navigation/CatalogNavigator.kt`
 
-- **core:base:data, core:music:data, core:book:data**
-    - `playback` - Media3 ExoPlayer wrapper and playback control
-    - `catalog` - Music catalog data source using Android MediaStore
-    - `storage:preferences` - SharedPreferences wrapper
-    - `storage:database:music` - SQLDelight database for playback queue persistence
+### UI state
+- `ScreenContentState` + `ScreenContentStateDelegate` for loading/error/empty/content
 
-- **core:entity**
-    - `catalog` - Song, Artist, Album entities
-    - `playback` - SongInQueueItem entities
-    - `queue` - Queue domain model
+### Playback
+- `PlaybackController` — music queue API (`core:music:data:playback`)
+- `PlaybackPlayer` — ExoPlayer wrapper (`core:base:data:playback`)
+- `PlaybackService` — background `MediaSessionService` (`core:base:presentation:background_player`)
+- Queue persisted via SQLDelight `Queue.sq`
+- Equalizer shared across all apps: `EqualizerComponent` in `core:base:presentation:player`
 
-- **core:presentation**
-    - `catalog` - Catalog browsing (Artists → Albums → Songs)
-    - `player` - Full player and mini player views
-    - `playlist:queue` - Current queue management UI
-    - `background_player` - Background playback service with Media3 MediaSession
+### Strings & resources
+- KMP modules: `src/commonMain/composeResources/values/strings.xml` (+ `values-ru/`)
+  - Generated access: `Res.string.*` (package set in `compose.resources { packageOfResClass }`)
+- Android app strings: `apps/*/src/main/res/values/strings.xml`
+- Locales: `en`, `ru` (`androidResources.localeFilters`)
 
-- **core:platform**
-    - `permission` - Runtime permissions handling
+### Logger (external package)
+- Artifact: `com.github.k-tigre:logger-*` v1.0.2 from GitHub Packages
+- Needs `gpr.user`/`gpr.key` or `GITHUB_ACTOR`/`GITHUB_TOKEN` in Gradle
+- Debug/QA Android: Logcat + Crashlytics + Internal DB
+- Release Android: Crashlytics only
+- Desktop: `ConsoleLogger`
 
-- **tools**
-    - `coroutines` - Coroutine scope and extensions
-    - `entity` - Optional type wrapper
-    - `presentation:compose` - Compose UI utilities (Theme, Colors, Views)
-    - `presentation:decompose` - Decompose navigation base classes
-    - `platform:utils` - Platform-specific utilities
+---
 
-- **logger** - Multi-backend logging (Logcat, Crashlytics, Internal DB)
+## Recipe: add a new screen (Decompose)
 
-- **debug:settings** - Debug-only UI for viewing internal logs
+1. Add `@Serializable` config to parent's sealed `*Config` class
+2. Create `*Component.kt` (interface + Impl extending `BaseComponentContext`)
+3. Create `*View.kt` with `ComposableView.Draw()`
+4. Add `*Navigator.kt` interface; implement in parent component or app `Root`
+5. Add factory methods to `*ComponentProvider` / `*ViewProvider`
+6. Register child in parent's `appChildStack` factory
+7. If new data needed: add to `*Dependency` interface + wire in `ApplicationGraph`
 
-### Key Architectural Patterns
-#### Manual Dependency Injection
-The app uses manual DI with a simple graph pattern:
+Put shared UI in `core:*:presentation:*`; put app-specific nav wiring in `apps:*`.
 
-- `ApplicationGraph` is the root DI container created in `App.onCreate()`
-- Each module defines a `*Dependency` interface and a `*Module` implementation
-- Components are created via `*ComponentProvider` interfaces that take dependencies as constructor parameters
-- See `ApplicationGraph.create()` in `apps/PlayerApp/src/main/java/by/tigre/music/player/core/di/ApplicationGraph.kt` and
-  `apps/AudioBook/src/main/java/by/tigre/audiobook/core/di/ApplicationGraph.kt`
+---
 
-#### Decompose Navigation
+## Recipe: add a new Gradle module
 
-Navigation uses Arkivanov Decompose for state‑preserving navigation:
+1. Add `include(":...")` in `settings.gradle.kts`
+2. Add enum entry in `buildSrc/.../Dependencies.kt` → `Project` sealed class
+3. Create `build.gradle.kts` following a sibling module (KMP vs Android-only)
+4. Wire `implementation(project(...))` from dependent modules
+5. KMP modules: `commonMain` + `androidMain` + `jvm("desktop")`, `jvmToolchain(21)`
 
-- Components implement interfaces and are created via Providers
-- Navigation is handled via `StackNavigation` with sealed config classes
-- Components have corresponding `*ViewProvider` for UI rendering
-- See `RootCatalogComponent` for an example of nested navigation (Artists → Albums → Songs)
+---
 
-#### BaseComponentContext
-All components extend `BaseComponentContext` which combines `ComponentContext` (Decompose lifecycle/state saving) with a
-`CoroutineScope`. See
-`tools/presentation/decompose/src/main/kotlin/by/tigre/music/player/presentation/base/BaseComponentContext.kt`.
+## Stable quirks — do NOT "fix" without a migration plan
 
-#### View/Component Separation
-Each feature follows this pattern:
-- `*Component.kt` - Logic layer (interface + Impl class)
-- `*View.kt` - UI layer (Compose composable with `.Draw()` extension)
-- `*ComponentProvider.kt` - Factory for creating components with DI
-- `*ViewProvider.kt` - Factory for creating views
-- `navigation/*Navigator.kt` - Navigation interface
+| Quirk | Location |
+|-------|----------|
+| Package `entiry` (not `entity`) | `by.tigre.music.player.core.entiry.*`, `by.tigre.audiobook.core.entiry.*` |
+| Package `backgound_player` (not `background`) | Module dir is `background_player/`, but Kotlin package is `...presentation.backgound_player.*` |
+| App ID `by.tigre.musicplayer` vs package `by.tigre.music.player` | Intentional mismatch |
 
-#### Playback Architecture
-Music playback uses AndroidX Media3 (ExoPlayer):
-- `PlaybackController` - Main playback API with queue management
-- `PlaybackPlayer` - ExoPlayer wrapper interface
-- `PlaybackService` - MediaSessionService for background playback with media controls
-- Queue state is persisted via SQLDelight (`Queue.sq`)
-- See `core:data:playback` module
+---
 
-#### Logger
-- `Log.init()` is called in `App.onCreate()`
-- Debug/QA builds: Logcat, Crashlytics, and Internal DB logger
-- Release builds: Crashlytics only
-- See `logger/core` and `logger/internal-store` modules
+## Build & verify
 
-### Key File Locations
+Windows: use `gradlew.bat` instead of `./gradlew`.
 
-- App entry point (Music Player): `apps/PlayerApp/src/main/java/by/tigre/music/player/App.kt`
-- Main activity (Music Player): `apps/PlayerApp/src/main/java/by/tigre/music/player/MainActivity.kt`
-- Root DI graph: `apps/PlayerApp/src/main/java/by/tigre/music/player/core/di/ApplicationGraph.kt` and
-  `apps/AudioBook/src/main/java/by/tigre/audiobook/core/di/ApplicationGraph.kt`
-- Root navigation component (Music Player): `apps/PlayerApp/src/main/java/by/tigre/music/player/presentation/root/component/Root.kt`
-- Dependency versions: `buildSrc/src/main/kotlin/Dependencies.kt`
-- App configuration: `buildSrc/src/main/kotlin/Application.kt`
-- Module registry: `settings.gradle.kts`
+```bash
+# Android — install debug
+./gradlew :apps:PlayerApp:installDebug
+./gradlew :apps:AudioBook:installDebug
 
-### Key Dependencies
+# Desktop — run
+./gradlew :apps:PlayerDesktop:run
 
-- **Kotlin** 2.1.21 | **AGP** 8.13.2 | **Gradle** 8.9
-- **Jetpack Compose** 1.8.0 | **Material3** 1.4.0
-- **Decompose** 3.4.0
-- **Media3** 1.5.0
-- **SQLDelight** 2.2.1
-- **Coroutines** 1.10.2
-- **Firebase BOM** 34.0.0 (Crashlytics + Analytics)
-- **Coil Compose** 3.1.0
+# Build variants (both Android apps)
+./gradlew assembleDebug      # debuggable, no minify, .dev suffix
+./gradlew assembleQa         # debuggable, minify, .dev suffix, Firebase distribution
+./gradlew assembleRelease    # requires signing env vars
+
+# Tests (no test sources exist yet; command is prepared)
+./gradlew test
+
+# After editing .sq files
+./gradlew generateSqlDelightInterface
+
+# Dependency updates
+./gradlew dependencyUpdates
+```
+
+### Build variants
+
+| Variant | Debuggable | Minify | App ID suffix | App name suffix |
+|---------|------------|--------|---------------|-----------------|
+| debug | yes | no | `.dev` | ` Dev` |
+| qa | yes | yes | `.dev` | ` Qa` |
+| release | no | yes | none | none |
+
+### Signing env vars
+
+- Music Player: `MUSIC_PLAYER_RELEASE_JKS_STORE_PASSWORD`, `MUSIC_PLAYER_RELEASE_JKS_KEY_PASSWORD`
+- AudioBook: `AUDIO_BOOK_RELEASE_JKS_STORE_PASSWORD`, `AUDIO_BOOK_RELEASE_JKS_KEY_PASSWORD`
+
+---
+
+## Platform & versions
+
+| Setting | Value |
+|---------|-------|
+| Kotlin | 2.1.21 |
+| AGP | 8.13.2 |
+| Gradle | 8.9 |
+| JVM toolchain | 21 |
+| Compile SDK | 36 |
+| Target SDK | 35 |
+| Min SDK | 26 |
+| Compose (Android) | 1.8.0 |
+| Compose Multiplatform | 1.8.1 |
+| Material3 | 1.4.0 |
+| Decompose | 3.4.0 |
+| Media3 | 1.5.0 |
+| SQLDelight | 2.2.1 |
+| Coroutines | 1.10.2 |
+| Firebase BOM | 34.0.0 |
+| Coil | 3.1.0 |
+
+App versions: Music Player `0.17.0`, AudioBook `0.2.0`, Desktop `1.0.5`.
+
+---
+
+## Coding constraints for AI agents
+
+1. **Minimize scope** — match existing patterns in the nearest sibling file; no drive-by refactors
+2. **Respect module boundaries** — don't import `apps:*` from `core:*`; don't put Android APIs in `entity`
+3. **Both apps may need wiring** — if changing shared `core:*`, check PlayerApp AND AudioBook `ApplicationGraph` / `Root`
+4. **KMP source sets** — platform code in `androidMain`/`desktopMain`, shared in `commonMain`
+5. **No tests exist** — don't claim test coverage; run relevant `assembleDebug` or `:apps:PlayerDesktop:run` to verify
+6. **Don't rename `entiry`/`backgound_player`** — breaks imports across the entire codebase
+7. **Commits/PRs** — only when explicitly asked by the user

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ app (work in progress) that shares the same core modules.
 - **PlayerDesktop** — desktop client in Kotlin and Jetpack Compose for desktop OSes (native installers: MSI, DMG, DEB).
 - **AudioBook** — separate Android app for audiobooks (WIP), same overall architecture as the music player.
 
-Stack: Kotlin, Jetpack Compose, Decompose (navigation), SQLDelight (queue), Coil, Firebase Crashlytics (mobile builds). Developer-oriented
-details are in [`CLAUDE.md`](CLAUDE.md).
+Stack: Kotlin, Jetpack Compose, Decompose (navigation), SQLDelight (queue), Coil, Firebase Crashlytics (mobile builds).
+
+**For AI agents and contributors:** architecture, module map, task routing, and build commands are in [`CLAUDE.md`](CLAUDE.md) (canonical) and [`AGENTS.md`](AGENTS.md) (quick index).
 
 ## Requirements
 

--- a/apps/AudioBook/src/main/java/by/tigre/audiobook/core/di/ApplicationGraph.kt
+++ b/apps/AudioBook/src/main/java/by/tigre/audiobook/core/di/ApplicationGraph.kt
@@ -88,6 +88,10 @@ class ApplicationGraph(
             override fun setOrderMode(isNormal: Boolean) = Unit
             override fun onSeekPositionCommitted(positionMs: Long) =
                 controller.persistPlaybackPositionAfterSeek(positionMs)
+            override fun seekBy(deltaMs: Long): Boolean {
+                controller.seekBy(deltaMs)
+                return true
+            }
         }
     }
 

--- a/apps/AudioBook/src/main/java/by/tigre/audiobook/presentation/root/component/Root.kt
+++ b/apps/AudioBook/src/main/java/by/tigre/audiobook/presentation/root/component/Root.kt
@@ -121,6 +121,7 @@ interface Root {
 
         override fun onShowCatalog() {
             mainNavigation.pushToFront(MainConfig.Main)
+            audiobookCatalogComponent.focusCurrentBookInLibrary()
         }
 
         override fun onOpenFolderSettings() {

--- a/apps/AudioBook/src/main/java/by/tigre/audiobook/presentation/root/view/RootView.kt
+++ b/apps/AudioBook/src/main/java/by/tigre/audiobook/presentation/root/view/RootView.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import by.tigre.audiobook.R
 import by.tigre.audiobook.core.data.audiobook_playback.AudiobookPlaybackController
 import by.tigre.audiobook.core.presentation.audiobook_catalog.di.AudiobookCatalogViewProvider
+import by.tigre.audiobook.core.presentation.audiobook_catalog.view.AudiobookChapterSelector
 import by.tigre.audiobook.nighttimer.NightTimerController
 import by.tigre.audiobook.nighttimer.NightTimerSettingsScreen
 import by.tigre.audiobook.presentation.root.component.Root
@@ -85,6 +86,12 @@ class RootView(
                                 equalizerMenuLabel = stringResource(R.string.player_equalizer_menu),
                                 queueMenuLabel = stringResource(R.string.player_queue_menu),
                             ),
+                            chapterTitleContent = { chapterTitle ->
+                                AudiobookChapterSelector(
+                                    controller = audiobookPlaybackController,
+                                    chapterTitle = chapterTitle,
+                                )
+                            },
                             topBarContent = {
                                 val eqAvailable by child.component.playbackEqualizer.isAvailable.collectAsState()
                                 val nightUi by nightTimerController.uiState.collectAsState()

--- a/core/base/presentation/player/src/commonMain/kotlin/by/tigre/music/player/core/presentation/catalog/component/BasePlaybackController.kt
+++ b/core/base/presentation/player/src/commonMain/kotlin/by/tigre/music/player/core/presentation/catalog/component/BasePlaybackController.kt
@@ -19,4 +19,10 @@ interface BasePlaybackController {
 
     /** Called when the user releases the seek slider; [positionMs] is the intended time in the current item. */
     fun onSeekPositionCommitted(positionMs: Long) = Unit
+
+    /**
+     * Relative seek (e.g. ±15s). Return true if the controller handled cross-item seeking;
+     * false to fall back to seeking within the current media item only.
+     */
+    fun seekBy(deltaMs: Long): Boolean = false
 }

--- a/core/base/presentation/player/src/commonMain/kotlin/by/tigre/music/player/core/presentation/catalog/component/BasePlayerComponent.kt
+++ b/core/base/presentation/player/src/commonMain/kotlin/by/tigre/music/player/core/presentation/catalog/component/BasePlayerComponent.kt
@@ -170,6 +170,7 @@ internal class BasePlayerComponentImpl(
 
     private fun seekBy(deltaMs: Long) {
         launch {
+            if (basePlaybackController.seekBy(deltaMs)) return@launch
             val progress = basePlaybackController.player.progress.first()
             val duration = progress.duration.coerceAtLeast(0L)
             val target = (progress.position + deltaMs).coerceIn(0L, duration)

--- a/core/base/presentation/player/src/commonMain/kotlin/by/tigre/music/player/core/presentation/catalog/di/PlayerViewProvider.kt
+++ b/core/base/presentation/player/src/commonMain/kotlin/by/tigre/music/player/core/presentation/catalog/di/PlayerViewProvider.kt
@@ -17,7 +17,8 @@ interface PlayerViewProvider {
     fun createPlayerView(
         component: PlayerComponent,
         config: PlayerView.Config,
-        topBarContent: (@Composable () -> Unit)? = null
+        topBarContent: (@Composable () -> Unit)? = null,
+        chapterTitleContent: (@Composable (title: String) -> Unit)? = null
     ): ComposableView
 
     fun createEqualizerView(component: EqualizerComponent, showTopBar: Boolean = true): ComposableView
@@ -32,8 +33,9 @@ interface PlayerViewProvider {
         override fun createPlayerView(
             component: PlayerComponent,
             config: PlayerView.Config,
-            topBarContent: (@Composable () -> Unit)?
-        ): PlayerView = PlayerView(component, config, topBarContent)
+            topBarContent: (@Composable () -> Unit)?,
+            chapterTitleContent: (@Composable (title: String) -> Unit)?,
+        ): PlayerView = PlayerView(component, config, topBarContent, chapterTitleContent)
 
         override fun createEqualizerView(component: EqualizerComponent, showTopBar: Boolean): EqualizerView =
             EqualizerView(component, showTopBar = showTopBar)

--- a/core/base/presentation/player/src/commonMain/kotlin/by/tigre/music/player/core/presentation/catalog/view/PlayerView.kt
+++ b/core/base/presentation/player/src/commonMain/kotlin/by/tigre/music/player/core/presentation/catalog/view/PlayerView.kt
@@ -66,6 +66,7 @@ class PlayerView(
     private val component: PlayerComponent,
     private val config: Config,
     private val topBarContent: (@Composable () -> Unit)? = null,
+    private val chapterTitleContent: (@Composable (title: String) -> Unit)? = null,
 ) : ComposableView {
 
     @Composable
@@ -172,10 +173,14 @@ class PlayerView(
                     .fillMaxWidth()
                     .animateContentSize()
             ) {
-                Text(
-                    text = item.title,
-                    style = MaterialTheme.typography.headlineMedium
-                )
+                if (chapterTitleContent != null) {
+                    chapterTitleContent.invoke(item.title)
+                } else {
+                    Text(
+                        text = item.title,
+                        style = MaterialTheme.typography.headlineMedium
+                    )
+                }
 
                 Text(
                     text = item.subtitle,

--- a/core/book/data/playback/src/commonMain/kotlin/by/tigre/audiobook/core/data/audiobook_playback/AudiobookPlaybackController.kt
+++ b/core/book/data/playback/src/commonMain/kotlin/by/tigre/audiobook/core/data/audiobook_playback/AudiobookPlaybackController.kt
@@ -10,6 +10,7 @@ interface AudiobookPlaybackController {
     val player: PlaybackPlayer
     val currentBook: StateFlow<Book?>
     val currentChapter: StateFlow<Chapter?>
+    val chapters: StateFlow<List<Chapter>>
     /** True after the book ends; cleared when the user seeks back or starts playback again. */
     val bookFinishedBannerVisible: StateFlow<Boolean>
 
@@ -18,6 +19,7 @@ interface AudiobookPlaybackController {
     fun playBookChapter(bookId: Book.Id, chapterId: Chapter.Id)
     fun playNextChapter()
     fun playPrevChapter()
+    fun jumpToChapter(chapterId: Chapter.Id)
     fun pause()
     fun resume()
     fun stop()

--- a/core/book/data/playback/src/commonMain/kotlin/by/tigre/audiobook/core/data/audiobook_playback/impl/AudiobookPlaybackControllerImpl.kt
+++ b/core/book/data/playback/src/commonMain/kotlin/by/tigre/audiobook/core/data/audiobook_playback/impl/AudiobookPlaybackControllerImpl.kt
@@ -34,9 +34,8 @@ internal class AudiobookPlaybackControllerImpl(
 
     override val currentBook = MutableStateFlow<Book?>(null)
     override val currentChapter = MutableStateFlow<Chapter?>(null)
+    override val chapters = MutableStateFlow<List<Chapter>>(emptyList())
     override val bookFinishedBannerVisible = MutableStateFlow(false)
-
-    private val chapters = MutableStateFlow<List<Chapter>>(emptyList())
     private val isPlaying = MutableStateFlow(false)
 
     /** Monotonic mark when [pause] was invoked; used to rewind on [resume]. */
@@ -182,6 +181,21 @@ internal class AudiobookPlaybackControllerImpl(
         }
     }
 
+    override fun jumpToChapter(chapterId: Chapter.Id) {
+        Log.d(TAG) { "jumpToChapter: chapterId=$chapterId" }
+        scope.launch {
+            val chapter = chapters.value.firstOrNull { it.id == chapterId } ?: return@launch
+            dismissBookFinishedBanner()
+            clearPauseRewindState()
+            loadCanonicalListenedMs = null
+            mayPersistBelowCanonical = false
+            saveCurrentPosition()
+            setChapter(chapter, 0L)
+            resumePlaybackIfDesired()
+            saveCurrentPosition()
+        }
+    }
+
     override fun playPrevChapter() {
         Log.d(TAG) { "playPrevChapter" }
         scope.launch {
@@ -251,15 +265,16 @@ internal class AudiobookPlaybackControllerImpl(
 
     override fun seekBy(deltaMs: Long) {
         scope.launch {
+            if (deltaMs == 0L) return@launch
             if (deltaMs < 0L) {
                 dismissBookFinishedBanner()
+            } else {
+                dismissBookFinishedBanner()
             }
-            val progress = player.progress.first()
-            val duration = progress.duration.coerceAtLeast(0L)
-            val target = (progress.position + deltaMs).coerceIn(0L, duration)
-            player.seekTo(target)
+            clearPauseRewindState()
             mayPersistBelowCanonical = true
-            persistPlaybackPosition(target)
+            seekAcrossChapters(deltaMs)
+            saveCurrentPosition()
         }
     }
 
@@ -392,6 +407,14 @@ internal class AudiobookPlaybackControllerImpl(
         return (minMs + (maxMs - minMs) * fraction).toLong()
     }
 
+    private suspend fun seekAcrossChapters(deltaMs: Long) {
+        if (deltaMs < 0L) {
+            rewindAcrossChapters(-deltaMs)
+        } else {
+            forwardAcrossChapters(deltaMs)
+        }
+    }
+
     /**
      * Moves playback back by [rewindMs] within the current chapter; overflow goes to the previous chapter(s)
      * from the end of each file, same as rewinding from the chapter boundary.
@@ -430,6 +453,55 @@ internal class AudiobookPlaybackControllerImpl(
         }
 
         setChapter(chapterList.first(), 0L)
+    }
+
+    private suspend fun forwardAcrossChapters(forwardMs: Long) {
+        val chapterList = chapters.value
+        if (chapterList.isEmpty()) return
+        val current = currentChapter.value ?: return
+        var chapterIndex = chapterList.indexOfFirst { it.id == current.id }
+        if (chapterIndex < 0) return
+
+        val positionMs = player.progress.first().position.coerceAtLeast(0L)
+        var remaining = forwardMs
+
+        val currentDurationMs = chapterList[chapterIndex].duration.coerceAtLeast(0L)
+        if (currentDurationMs > 0L && positionMs + remaining <= currentDurationMs) {
+            player.seekTo(positionMs + remaining)
+            return
+        }
+
+        if (currentDurationMs > 0L) {
+            remaining -= (currentDurationMs - positionMs)
+        }
+        chapterIndex++
+
+        while (chapterIndex < chapterList.size && remaining > 0) {
+            val chapter = chapterList[chapterIndex]
+            val durationMs = chapter.duration.coerceAtLeast(0L)
+            if (durationMs == 0L) {
+                chapterIndex++
+                continue
+            }
+            if (remaining < durationMs) {
+                setChapter(chapter, remaining)
+                return
+            }
+            if (remaining == durationMs) {
+                if (chapterIndex < chapterList.size - 1) {
+                    setChapter(chapterList[chapterIndex + 1], 0L)
+                } else {
+                    setChapter(chapter, durationMs)
+                }
+                return
+            }
+            remaining -= durationMs
+            chapterIndex++
+        }
+
+        val lastChapter = chapterList.last()
+        val endMs = lastChapter.duration.coerceAtLeast(0L)
+        setChapter(lastChapter, endMs)
     }
 
     private suspend fun saveBookProgressCompleted(book: Book, chapterList: List<Chapter>) {

--- a/core/book/presentation/catalog/src/commonMain/composeResources/values-ru/strings.xml
+++ b/core/book/presentation/catalog/src/commonMain/composeResources/values-ru/strings.xml
@@ -7,6 +7,12 @@
     <string name="book_chapters_count">Глав: %1$d</string>
     <string name="book_completed">Завершено</string>
     <string name="book_progress_listened">Прослушано %1$d%%</string>
+    <string name="continue_listening_title">Продолжить слушать</string>
+    <string name="book_currently_playing">Сейчас играет</string>
+    <string name="chapters_sheet_title">Главы</string>
+    <string name="chapter_fallback_title">Глава %1$d</string>
+    <string name="chapter_sheet_subtitle">%1$d из %2$d · с %3$s</string>
+    <string name="cd_select_chapter">Выбрать главу</string>
 
     <string name="folder_selection_title">Папки аудиокниг</string>
     <string name="nav_books">Книги</string>

--- a/core/book/presentation/catalog/src/commonMain/composeResources/values/strings.xml
+++ b/core/book/presentation/catalog/src/commonMain/composeResources/values/strings.xml
@@ -7,6 +7,12 @@
     <string name="book_chapters_count">Chapters: %1$d</string>
     <string name="book_completed">Completed</string>
     <string name="book_progress_listened">%1$d%% listened</string>
+    <string name="continue_listening_title">Continue listening</string>
+    <string name="book_currently_playing">Now playing</string>
+    <string name="chapters_sheet_title">Chapters</string>
+    <string name="chapter_fallback_title">Chapter %1$d</string>
+    <string name="chapter_sheet_subtitle">%1$d of %2$d · from %3$s</string>
+    <string name="cd_select_chapter">Select chapter</string>
 
     <string name="folder_selection_title">Audiobook Folders</string>
     <string name="nav_books">Books</string>

--- a/core/book/presentation/catalog/src/commonMain/kotlin/by/tigre/audiobook/core/presentation/audiobook_catalog/component/BookListComponent.kt
+++ b/core/book/presentation/catalog/src/commonMain/kotlin/by/tigre/audiobook/core/presentation/audiobook_catalog/component/BookListComponent.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 
 interface BookListComponent {
 
@@ -23,11 +24,15 @@ interface BookListComponent {
     fun onManageFolders()
     fun retry()
     fun toggleGroup(path: String)
+    fun focusCurrentBook()
 
     data class BookListUiState(
+        val continueListeningBook: Book?,
         val rootBooks: List<Book>,
         val grouped: List<Pair<String, List<Book>>>,
-        val expanded: Set<String>
+        val expanded: Set<String>,
+        val currentBookId: Book.Id?,
+        val scrollToBookNonce: Long,
     )
 
     class Impl(
@@ -41,25 +46,41 @@ interface BookListComponent {
         private val playbackController: AudiobookPlaybackController = dependency.audiobookPlaybackController
 
         private val expandedState = MutableStateFlow(emptySet<String>())
+        private val scrollToBookNonce = MutableStateFlow(0L)
 
         override val screenState: StateFlow<ScreenContentState<BookListUiState>> = combine(
-            catalogSource.books
-                .map { books ->
-                    val rootBooks = books.filter { it.subPath.isEmpty() }
-                    val grouped = books
-                        .filter { it.subPath.isNotEmpty() }
-                        .groupBy { it.subPath }
-                        .entries
-                        .sortedBy { it.key }
-                        .map { it.key to it.value }
-                    rootBooks to grouped
-                }, expandedState
-        ) { (rootBooks, grouped), _ ->
+            catalogSource.books,
+            playbackController.currentBook,
+            expandedState,
+            scrollToBookNonce,
+        ) { books, currentBook, expanded, scrollNonce ->
+            val currentBookId = currentBook?.id
+            val continueListeningBook = currentBook?.takeUnless { it.isCompleted }
+            val otherBooks = if (currentBookId != null) {
+                books.filter { it.id != currentBookId }
+            } else {
+                books
+            }
+            val rootBooks = otherBooks.filter { it.subPath.isEmpty() }
+            val grouped = otherBooks
+                .filter { it.subPath.isNotEmpty() }
+                .groupBy { it.subPath }
+                .entries
+                .sortedBy { it.key }
+                .map { it.key to it.value }
+            val expandedWithCurrent = if (currentBook?.subPath?.isNotEmpty() == true) {
+                expanded + currentBook.subPath
+            } else {
+                expanded
+            }
             ScreenContentState.Content(
                 BookListUiState(
-                    rootBooks,
-                    grouped,
-                    expandedState.value
+                    continueListeningBook = continueListeningBook,
+                    rootBooks = rootBooks,
+                    grouped = grouped,
+                    expanded = expandedWithCurrent,
+                    currentBookId = currentBookId,
+                    scrollToBookNonce = scrollNonce,
                 )
             )
         }
@@ -79,8 +100,13 @@ interface BookListComponent {
         }
 
         override fun toggleGroup(path: String) {
-            val current = expandedState.value
-            expandedState.value = if (current.contains(path)) current - path else current + path
+            expandedState.update { current ->
+                if (current.contains(path)) current - path else current + path
+            }
+        }
+
+        override fun focusCurrentBook() {
+            scrollToBookNonce.update { it + 1L }
         }
     }
 }

--- a/core/book/presentation/catalog/src/commonMain/kotlin/by/tigre/audiobook/core/presentation/audiobook_catalog/component/RootAudiobookCatalogComponent.kt
+++ b/core/book/presentation/catalog/src/commonMain/kotlin/by/tigre/audiobook/core/presentation/audiobook_catalog/component/RootAudiobookCatalogComponent.kt
@@ -17,6 +17,7 @@ interface RootAudiobookCatalogComponent {
     val childStack: Value<ChildStack<*, AudiobookCatalogChild>>
 
     fun openFolderSelection()
+    fun focusCurrentBookInLibrary()
 
     sealed interface AudiobookCatalogChild {
         class FolderSelection(val component: FolderSelectionComponent) : AudiobookCatalogChild
@@ -67,6 +68,12 @@ interface RootAudiobookCatalogComponent {
 
         override fun openFolderSelection() {
             navigation.bringToFront(Config.FolderSelection)
+        }
+
+        override fun focusCurrentBookInLibrary() {
+            navigation.bringToFront(Config.BookList)
+            val bookListChild = stack.value.active.instance as? AudiobookCatalogChild.BookList
+            bookListChild?.component?.focusCurrentBook()
         }
 
         @Serializable

--- a/core/book/presentation/catalog/src/commonMain/kotlin/by/tigre/audiobook/core/presentation/audiobook_catalog/view/AudiobookChapterSelector.kt
+++ b/core/book/presentation/catalog/src/commonMain/kotlin/by/tigre/audiobook/core/presentation/audiobook_catalog/view/AudiobookChapterSelector.kt
@@ -1,0 +1,257 @@
+package by.tigre.audiobook.core.presentation.audiobook_catalog.view
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import by.tigre.audiobook.core.data.audiobook_playback.AudiobookPlaybackController
+import by.tigre.audiobook.core.entity.catalog.Chapter
+import by.tigre.audiobook.core.presentation.catalog.resources.Res
+import by.tigre.audiobook.core.presentation.catalog.resources.book_currently_playing
+import by.tigre.audiobook.core.presentation.catalog.resources.cd_select_chapter
+import by.tigre.audiobook.core.presentation.catalog.resources.chapters_sheet_title
+import org.jetbrains.compose.resources.stringResource
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AudiobookChapterSelector(
+    controller: AudiobookPlaybackController,
+    chapterTitle: String,
+    modifier: Modifier = Modifier,
+) {
+    val chapters by controller.chapters.collectAsState()
+    val currentChapter by controller.currentChapter.collectAsState()
+    var sheetVisible by remember { mutableStateOf(false) }
+    val canSelect = chapters.size > 1
+    val currentIndex = chapters.indexOfFirst { it.id == currentChapter?.id }
+    val displayTitle = chapterDisplayTitle(chapterTitle, currentIndex)
+
+    Column(
+        modifier = modifier
+            .clickable(enabled = canSelect) { sheetVisible = true }
+            .padding(vertical = 4.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = displayTitle,
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.primary,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f, fill = false),
+            )
+            if (canSelect) {
+                Icon(
+                    imageVector = Icons.Default.ArrowDropDown,
+                    contentDescription = stringResource(Res.string.cd_select_chapter),
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(28.dp),
+                )
+            }
+        }
+        if (currentIndex >= 0 && chapters.isNotEmpty()) {
+            Text(
+                text = chapterSheetSubtitle(
+                    rawTitle = chapterTitle,
+                    index = currentIndex,
+                    totalChapters = chapters.size,
+                    offsetMs = chapterOffsetMs(chapters, currentIndex),
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+        }
+    }
+
+    if (sheetVisible && canSelect) {
+        val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        val listState = rememberLazyListState()
+
+        LaunchedEffect(sheetVisible) {
+            if (currentIndex >= 0) {
+                listState.scrollToItem(currentIndex)
+            }
+        }
+
+        ModalBottomSheet(
+            onDismissRequest = { sheetVisible = false },
+            sheetState = sheetState,
+        ) {
+            Text(
+                text = stringResource(Res.string.chapters_sheet_title),
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
+            )
+            LazyColumn(
+                state = listState,
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                    start = 16.dp,
+                    end = 16.dp,
+                    bottom = 24.dp,
+                ),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                itemsIndexed(
+                    items = chapters,
+                    key = { _, chapter -> chapter.id.value },
+                ) { index, chapter ->
+                    ChapterSheetRow(
+                        index = index,
+                        chapter = chapter,
+                        totalChapters = chapters.size,
+                        offsetMs = chapterOffsetMs(chapters, index),
+                        isCurrent = chapter.id == currentChapter?.id,
+                        onClick = {
+                            sheetVisible = false
+                            if (chapter.id != currentChapter?.id) {
+                                controller.jumpToChapter(chapter.id)
+                            }
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChapterSheetRow(
+    index: Int,
+    chapter: Chapter,
+    totalChapters: Int,
+    offsetMs: Long,
+    isCurrent: Boolean,
+    onClick: () -> Unit,
+) {
+    val shape = RoundedCornerShape(12.dp)
+    val backgroundColor = if (isCurrent) {
+        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.55f)
+    } else {
+        MaterialTheme.colorScheme.surfaceContainerLow
+    }
+    val borderColor = if (isCurrent) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        MaterialTheme.colorScheme.outlineVariant
+    }
+    val title = chapterDisplayTitle(chapter.title, index)
+    val subtitle = chapterSheetSubtitle(
+        rawTitle = chapter.title,
+        index = index,
+        totalChapters = totalChapters,
+        offsetMs = offsetMs,
+    )
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(shape)
+            .border(
+                width = if (isCurrent) 1.5.dp else 1.dp,
+                color = borderColor,
+                shape = shape,
+            )
+            .background(backgroundColor)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        if (isCurrent) {
+            Icon(
+                imageVector = Icons.Default.PlayArrow,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(24.dp),
+            )
+        } else {
+            Text(
+                text = "${index + 1}",
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(width = 24.dp, height = 20.dp),
+            )
+        }
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            if (isCurrent) {
+                Text(
+                    text = stringResource(Res.string.book_currently_playing),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = if (isCurrent) FontWeight.SemiBold else FontWeight.Normal,
+                color = if (isCurrent) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.onSurface
+                },
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = if (isCurrent) {
+                    MaterialTheme.colorScheme.onPrimaryContainer
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        Text(
+            text = formatChapterDuration(chapter.duration),
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = if (isCurrent) FontWeight.SemiBold else FontWeight.Normal,
+            color = if (isCurrent) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            },
+        )
+    }
+}

--- a/core/book/presentation/catalog/src/commonMain/kotlin/by/tigre/audiobook/core/presentation/audiobook_catalog/view/BookListView.kt
+++ b/core/book/presentation/catalog/src/commonMain/kotlin/by/tigre/audiobook/core/presentation/audiobook_catalog/view/BookListView.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -17,10 +18,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -31,12 +34,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import by.tigre.audiobook.core.entity.catalog.Book
@@ -47,8 +52,10 @@ import by.tigre.audiobook.core.presentation.catalog.resources.audiobooks_empty_t
 import by.tigre.audiobook.core.presentation.catalog.resources.audiobooks_title
 import by.tigre.audiobook.core.presentation.catalog.resources.book_chapters_count
 import by.tigre.audiobook.core.presentation.catalog.resources.book_completed
+import by.tigre.audiobook.core.presentation.catalog.resources.book_currently_playing
 import by.tigre.audiobook.core.presentation.catalog.resources.book_progress_listened
 import by.tigre.audiobook.core.presentation.catalog.resources.cd_manage_folders
+import by.tigre.audiobook.core.presentation.catalog.resources.continue_listening_title
 import by.tigre.music.player.presentation.base.ScreenContentState
 import by.tigre.music.player.tools.platform.compose.ComposableView
 import by.tigre.music.player.tools.platform.compose.view.ErrorScreen
@@ -116,7 +123,7 @@ class BookListView(
     @OptIn(ExperimentalFoundationApi::class)
     @Composable
     private fun DrawContent(state: BookListComponent.BookListUiState) {
-        if (state.rootBooks.isEmpty() && state.grouped.isEmpty()) {
+        if (state.continueListeningBook == null && state.rootBooks.isEmpty() && state.grouped.isEmpty()) {
             Column(
                 modifier = Modifier
                     .fillMaxSize()
@@ -136,9 +143,40 @@ class BookListView(
                 )
             }
         } else {
-            LazyColumn(contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)) {
-                println("AAAAAA::: Books: ${state.rootBooks.map { it.id }}")
-                items(items = state.rootBooks, key = { book -> book.id.value }) { book -> BookCard(book) }
+            val listState = rememberLazyListState()
+            LaunchedEffect(state.scrollToBookNonce) {
+                if (state.scrollToBookNonce > 0L) {
+                    listState.animateScrollToItem(0)
+                }
+            }
+
+            LazyColumn(
+                state = listState,
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+            ) {
+                state.continueListeningBook?.let { book ->
+                    item(key = "continue_${book.id.value}") {
+                        Text(
+                            text = stringResource(Res.string.continue_listening_title),
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.padding(start = 4.dp, top = 4.dp, bottom = 8.dp),
+                        )
+                        BookCard(
+                            book = book,
+                            isCurrent = true,
+                            showNowPlayingBadge = true,
+                        )
+                        Spacer(modifier = Modifier.size(12.dp))
+                    }
+                }
+
+                items(items = state.rootBooks, key = { book -> book.id.value }) { book ->
+                    BookCard(
+                        book = book,
+                        isCurrent = book.id == state.currentBookId,
+                    )
+                }
 
                 state.grouped.forEach { (path, booksInGroup) ->
                     stickyHeader(key = "header_$path") {
@@ -159,7 +197,12 @@ class BookListView(
                         }
                     }
                     if (state.expanded.contains(path)) {
-                        items(booksInGroup) { book -> BookCard(book) }
+                        items(booksInGroup, key = { book -> "group_${path}_${book.id.value}" }) { book ->
+                            BookCard(
+                                book = book,
+                                isCurrent = book.id == state.currentBookId,
+                            )
+                        }
                     }
                 }
             }
@@ -167,13 +210,32 @@ class BookListView(
     }
 
     @Composable
-    private fun BookCard(book: Book) {
+    private fun BookCard(
+        book: Book,
+        isCurrent: Boolean,
+        showNowPlayingBadge: Boolean = false,
+    ) {
+        val shape = RoundedCornerShape(12.dp)
+        val borderColor = if (isCurrent) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant
+        val containerColor = if (isCurrent) {
+            MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.45f)
+        } else {
+            MaterialTheme.colorScheme.surfaceContainerLow
+        }
+
         Card(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(vertical = 3.dp)
+                .padding(vertical = 4.dp)
                 .animateContentSize()
-                .clickable { component.onBookClicked(book) }
+                .border(
+                    width = if (isCurrent) 1.5.dp else 1.dp,
+                    color = borderColor,
+                    shape = shape,
+                )
+                .clickable { component.onBookClicked(book) },
+            shape = shape,
+            colors = CardDefaults.cardColors(containerColor = containerColor),
         ) {
             Row(
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
@@ -185,50 +247,65 @@ class BookListView(
                         model = cover,
                         contentDescription = null,
                         modifier = Modifier
-                            .size(56.dp)
+                            .size(64.dp)
                             .clip(RoundedCornerShape(8.dp)),
                         contentScale = ContentScale.Crop,
                     )
                     Spacer(modifier = Modifier.width(12.dp))
                 }
                 Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = book.title,
-                    style = MaterialTheme.typography.titleMedium
-                )
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        text = stringResource(Res.string.book_chapters_count, book.chapterCount),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    if (book.isCompleted) {
+                    if (showNowPlayingBadge) {
                         Text(
-                            text = stringResource(Res.string.book_completed),
+                            text = stringResource(Res.string.book_currently_playing),
                             style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                    } else if (book.progressFraction > 0f) {
-                        Text(
-                            text = stringResource(Res.string.book_progress_listened, (book.progressFraction * 100).toInt()),
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                            color = MaterialTheme.colorScheme.primary,
+                            fontWeight = FontWeight.SemiBold,
+                            modifier = Modifier.padding(bottom = 2.dp),
                         )
                     }
-                }
-                if (book.progressFraction > 0f || book.isCompleted) {
-                    LinearProgressIndicator(
-                        progress = { if (book.isCompleted) 1f else book.progressFraction },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 8.dp)
-                            .clip(RoundedCornerShape(4.dp)),
+                    Text(
+                        text = book.title,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = if (isCurrent) FontWeight.SemiBold else FontWeight.Normal,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
                     )
-                }
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = stringResource(Res.string.book_chapters_count, book.chapterCount),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        if (book.isCompleted) {
+                            Text(
+                                text = stringResource(Res.string.book_completed),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        } else if (book.progressFraction > 0f) {
+                            Text(
+                                text = stringResource(
+                                    Res.string.book_progress_listened,
+                                    (book.progressFraction * 100).toInt(),
+                                ),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                    if (book.progressFraction > 0f || book.isCompleted) {
+                        LinearProgressIndicator(
+                            progress = { if (book.isCompleted) 1f else book.progressFraction },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 8.dp)
+                                .clip(RoundedCornerShape(4.dp)),
+                        )
+                    }
                 }
             }
         }

--- a/core/book/presentation/catalog/src/commonMain/kotlin/by/tigre/audiobook/core/presentation/audiobook_catalog/view/ChapterDisplay.kt
+++ b/core/book/presentation/catalog/src/commonMain/kotlin/by/tigre/audiobook/core/presentation/audiobook_catalog/view/ChapterDisplay.kt
@@ -1,0 +1,75 @@
+package by.tigre.audiobook.core.presentation.audiobook_catalog.view
+
+import androidx.compose.runtime.Composable
+import by.tigre.audiobook.core.presentation.catalog.resources.Res
+import by.tigre.audiobook.core.presentation.catalog.resources.chapter_fallback_title
+import by.tigre.audiobook.core.presentation.catalog.resources.chapter_sheet_subtitle
+import org.jetbrains.compose.resources.stringResource
+
+internal fun isNonDescriptiveChapterTitle(title: String, index: Int): Boolean {
+    val raw = title.trim()
+    if (raw.isEmpty()) return true
+
+    val chapterNumber = index + 1
+    if (raw == chapterNumber.toString()) return true
+    if (raw == "%02d".format(chapterNumber)) return true
+    if (raw == "%03d".format(chapterNumber)) return true
+    if (raw.matches(Regex("^\\d{1,4}$"))) return true
+    if (raw.length <= 2) return true
+    if (raw.matches(Regex("^[\\d._\\-]+$"))) return true
+
+    val lower = raw.lowercase()
+    if (lower == "chapter $chapterNumber" || lower == "глава $chapterNumber") return true
+    if (lower == "track $chapterNumber" || lower == "трек $chapterNumber") return true
+
+    return false
+}
+
+@Composable
+internal fun chapterDisplayTitle(title: String, index: Int): String {
+    if (index < 0) return title
+    return if (isNonDescriptiveChapterTitle(title, index)) {
+        stringResource(Res.string.chapter_fallback_title, index + 1)
+    } else {
+        title
+    }
+}
+
+@Composable
+internal fun chapterSheetSubtitle(
+    rawTitle: String,
+    index: Int,
+    totalChapters: Int,
+    offsetMs: Long,
+): String {
+    val position = stringResource(
+        Res.string.chapter_sheet_subtitle,
+        index + 1,
+        totalChapters,
+        formatChapterDuration(offsetMs),
+    )
+    val raw = rawTitle.trim()
+    val showRawHint = isNonDescriptiveChapterTitle(raw, index) &&
+        raw.isNotEmpty() &&
+        !raw.matches(Regex("^\\d{1,4}$")) &&
+        !raw.equals(chapterDisplayTitle(rawTitle, index), ignoreCase = true)
+
+    return if (showRawHint) "$raw · $position" else position
+}
+
+internal fun chapterOffsetMs(chapters: List<by.tigre.audiobook.core.entity.catalog.Chapter>, index: Int): Long {
+    if (index <= 0) return 0L
+    return chapters.take(index).sumOf { it.duration.coerceAtLeast(0L) }
+}
+
+internal fun formatChapterDuration(durationMs: Long): String {
+    val totalSeconds = durationMs.coerceAtLeast(0L) / 1000
+    val hours = totalSeconds / 3600
+    val minutes = (totalSeconds % 3600) / 60
+    val seconds = totalSeconds % 60
+    return if (hours > 0) {
+        "%d:%02d:%02d".format(hours, minutes, seconds)
+    } else {
+        "%02d:%02d".format(minutes, seconds)
+    }
+}


### PR DESCRIPTION
## Summary

- **AudioBook playback UX:** chapter picker in the player, cross-chapter seek (forward/backward), and `jumpToChapter` API on `AudiobookPlaybackController`.
- **AudioBook library:** "Continue listening" section, highlight for the currently playing book, auto-expand its folder group, and scroll-to-top when opening the library from the player.
- **Shared player:** optional `chapterTitleContent` slot in `PlayerView` / `PlayerViewProvider`; `BasePlaybackController.seekBy` hook for app-specific relative seek behavior.
- **AI docs:** restructured `CLAUDE.md` (task routing, module map, recipes, stable quirks, updated SDK/JVM versions); added `AGENTS.md` quick index; linked from `README.md`.

## Test plan

- [ ] `./gradlew :apps:AudioBook:assembleDebug` builds successfully
- [ ] Open AudioBook, play a book with multiple chapters
- [ ] Tap chapter title in player — chapter sheet opens and jumping to a chapter works
- [ ] Use ±15s seek buttons — playback crosses chapter boundaries correctly
- [ ] Open library from player — current book appears in "Continue listening" and list scrolls to top
- [ ] Currently playing book is visually highlighted in the library list
- [ ] `./gradlew :apps:PlayerApp:assembleDebug` still builds (shared player API change)
